### PR TITLE
Add RWA 24h volume mat view + token→launchTreasury view

### DIFF
--- a/dipdup.local.yml
+++ b/dipdup.local.yml
@@ -5,7 +5,7 @@ package: equiteez
 database:
   kind: postgres
   host: 127.0.0.1
-  port: '5555'
+  port: '5432'
   user: dipdup
   password: dipdup12345
   database: dipdup
@@ -13,7 +13,7 @@ database:
   connection_timeout: 60
 
 hasura:
-  url: http://127.0.0.1:42007
+  url: http://127.0.0.1:42000
   allow_aggregations: false
   admin_secret: hasura12345
   select_limit: 1000
@@ -29,18 +29,8 @@ advanced:
     manual: wipe
     migration: exception
     rollback: ignore
-    config_modified: ignore
-    schema_modified: ignore
-  http:
-    retry_count: 60
-    retry_sleep: 30.0
-    retry_multiplier: 2.0
-    connection_timeout: 120
-  watchdog:
-    transaction:
-      timeout: 300
-    callback:
-      timeout: 300
+    config_modified: wipe
+    schema_modified: wipe
 
 datasources:
   metadata_atlasnet:
@@ -49,15 +39,5 @@ datasources:
     network: oxfordnet
   mvkt_atlasnet:
     kind: tezos.tzkt
-    url: ${TZKT_URL:-https://atlasnet.api.mavryk.network}
+    url: https://atlasnet.api.mavryk.network
     merge_subscriptions: true
-    http:
-      retry_count: 500
-      retry_sleep: 30.0
-      retry_multiplier: 2.0
-      connection_timeout: 60
-      batch_size: 10000
-
-
-
-

--- a/dipdup.local.yml
+++ b/dipdup.local.yml
@@ -5,7 +5,7 @@ package: equiteez
 database:
   kind: postgres
   host: 127.0.0.1
-  port: '5432'
+  port: '5555'
   user: dipdup
   password: dipdup12345
   database: dipdup
@@ -13,7 +13,7 @@ database:
   connection_timeout: 60
 
 hasura:
-  url: http://127.0.0.1:42000
+  url: http://127.0.0.1:42007
   allow_aggregations: false
   admin_secret: hasura12345
   select_limit: 1000
@@ -29,8 +29,18 @@ advanced:
     manual: wipe
     migration: exception
     rollback: ignore
-    config_modified: wipe
-    schema_modified: wipe
+    config_modified: ignore
+    schema_modified: ignore
+  http:
+    retry_count: 60
+    retry_sleep: 30.0
+    retry_multiplier: 2.0
+    connection_timeout: 120
+  watchdog:
+    transaction:
+      timeout: 300
+    callback:
+      timeout: 300
 
 datasources:
   metadata_atlasnet:
@@ -39,5 +49,15 @@ datasources:
     network: oxfordnet
   mvkt_atlasnet:
     kind: tezos.tzkt
-    url: https://atlasnet.api.mavryk.network
+    url: ${TZKT_URL:-https://atlasnet.api.mavryk.network}
     merge_subscriptions: true
+    http:
+      retry_count: 500
+      retry_sleep: 30.0
+      retry_multiplier: 2.0
+      connection_timeout: 60
+      batch_size: 10000
+
+
+
+

--- a/dipdup.yml
+++ b/dipdup.yml
@@ -523,6 +523,9 @@ hooks:
   refresh_launchpad_stats:
     callback: refresh_launchpad_stats
     atomic: False
+  refresh_rwa_volume:
+    callback: refresh_rwa_volume
+    atomic: False
 
 jobs:
   refresh_tokens:
@@ -534,3 +537,6 @@ jobs:
   refresh_launchpad_stats:
     hook: refresh_launchpad_stats
     interval: 60
+  refresh_rwa_volume:
+    hook: refresh_rwa_volume
+    interval: 300

--- a/dipdup.yml
+++ b/dipdup.yml
@@ -526,6 +526,9 @@ hooks:
   refresh_rwa_volume:
     callback: refresh_rwa_volume
     atomic: False
+  refresh_rwa_hold_time:
+    callback: refresh_rwa_hold_time
+    atomic: False
 
 jobs:
   refresh_tokens:
@@ -540,3 +543,6 @@ jobs:
   refresh_rwa_volume:
     hook: refresh_rwa_volume
     interval: 300
+  refresh_rwa_hold_time:
+    hook: refresh_rwa_hold_time
+    interval: 3600

--- a/equiteez/hooks/refresh_rwa_hold_time.py
+++ b/equiteez/hooks/refresh_rwa_hold_time.py
@@ -1,0 +1,14 @@
+import logging
+
+from dipdup.context import HookContext
+from tortoise import Tortoise
+
+logger = logging.getLogger(__name__)
+
+
+async def refresh_rwa_hold_time(ctx: HookContext) -> None:
+    conn = Tortoise.get_connection("default")
+    await conn.execute_query(
+        "REFRESH MATERIALIZED VIEW CONCURRENTLY token_avg_hold_time"
+    )
+    logger.debug("Refreshed token_avg_hold_time")

--- a/equiteez/hooks/refresh_rwa_volume.py
+++ b/equiteez/hooks/refresh_rwa_volume.py
@@ -1,0 +1,14 @@
+import logging
+
+from dipdup.context import HookContext
+from tortoise import Tortoise
+
+logger = logging.getLogger(__name__)
+
+
+async def refresh_rwa_volume(ctx: HookContext) -> None:
+    conn = Tortoise.get_connection("default")
+    await conn.execute_query(
+        "REFRESH MATERIALIZED VIEW CONCURRENTLY rwa_volume_24h_tokens"
+    )
+    logger.debug("Refreshed rwa_volume_24h_tokens")

--- a/equiteez/sql/on_reindex/05_create-launchpad-stats-view.sql
+++ b/equiteez/sql/on_reindex/05_create-launchpad-stats-view.sql
@@ -40,7 +40,7 @@ SELECT
                 AND t.address IS NOT NULL
             GROUP BY t.address
          ) per_token),
-        '{}'::jsonb
+        '{{}}'::jsonb
     ) AS total_raised_by_token
 FROM launchpad_launch l;
 

--- a/equiteez/sql/on_restart/01_create-rwa-volume-view.sql
+++ b/equiteez/sql/on_restart/01_create-rwa-volume-view.sql
@@ -1,0 +1,15 @@
+-- 24h RWA trading volume per token, denominated in RWA token units.
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS rwa_volume_24h_tokens AS
+SELECT
+    o.rwa_token_id           AS token_id,
+    SUM(oo.fulfilled_amount) AS volume_24h_tokens,
+    now()                    AS computed_at
+FROM orderbook o
+JOIN orderbook_order oo ON oo.orderbook_id = o.id
+WHERE oo.order_type = 1                                  -- OrderType.SELL (BUY=0, SELL=1)
+  AND oo.created_at >= now() - INTERVAL '24 hours'
+GROUP BY o.rwa_token_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_rwa_volume_24h_tokens_token_id
+    ON rwa_volume_24h_tokens(token_id);

--- a/equiteez/sql/on_restart/02_create-token-treasury-view.sql
+++ b/equiteez/sql/on_restart/02_create-token-treasury-view.sql
@@ -1,0 +1,10 @@
+-- Maps an RWA token to its launchTreasury address(es)
+
+CREATE OR REPLACE VIEW token_launch_treasury AS
+SELECT DISTINCT
+    l.token_id,
+    tr.address AS treasury_address
+FROM launchpad_launch l
+JOIN launchpad_treasury tr ON tr.launchpad_id = l.launchpad_id
+WHERE tr.name = 'launchTreasury'
+  AND l.token_id IS NOT NULL;

--- a/equiteez/sql/on_restart/03_create-avg-hold-time-view.sql
+++ b/equiteez/sql/on_restart/03_create-avg-hold-time-view.sql
@@ -1,0 +1,56 @@
+-- Average holding time (days) per RWA token, over current holders.
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS token_avg_hold_time AS
+WITH treasury AS (
+    SELECT DISTINCT l.token_id, tr.address
+    FROM launchpad_launch l
+    JOIN launchpad_treasury tr ON tr.launchpad_id = l.launchpad_id
+    WHERE tr.name = 'launchTreasury' AND l.token_id IS NOT NULL
+),
+flows AS (
+    -- primary purchases (MINT and TRANSFER), inflow
+    SELECT l.token_id, pe.user_id AS holder_id, pe.amount::numeric AS amt, pe.timestamp AS ts
+    FROM launchpad_purchase_event pe
+    JOIN launchpad_launch l ON l.id = pe.launch_id
+    WHERE l.token_id IS NOT NULL
+    UNION ALL
+    -- orderbook BUY fills, inflow to the buyer (initiator)
+    SELECT o.rwa_token_id, oo.initiator_id, oo.fulfilled_amount::numeric, COALESCE(oo.ended_at, oo.created_at)
+    FROM orderbook_order oo
+    JOIN orderbook o ON o.id = oo.orderbook_id
+    WHERE oo.order_type = 0 AND oo.fulfilled_amount > 0
+    UNION ALL
+    -- orderbook SELL fills, outflow from the seller (initiator)
+    SELECT o.rwa_token_id, oo.initiator_id, -oo.fulfilled_amount::numeric, COALESCE(oo.ended_at, oo.created_at)
+    FROM orderbook_order oo
+    JOIN orderbook o ON o.id = oo.orderbook_id
+    WHERE oo.order_type = 1 AND oo.fulfilled_amount > 0
+    UNION ALL
+    -- p2p in / out (tz→tz transfers)
+    SELECT tr.token_id, tr.to_user_id, tr.amount::numeric, tr.timestamp
+    FROM equiteez_user_token_transfer tr
+    UNION ALL
+    SELECT tr.token_id, tr.from_user_id, -tr.amount::numeric, tr.timestamp
+    FROM equiteez_user_token_transfer tr
+),
+holder_state AS (
+    SELECT token_id, holder_id,
+           SUM(amt)                       AS balance,
+           MIN(ts) FILTER (WHERE amt > 0) AS first_acquired
+    FROM flows
+    GROUP BY token_id, holder_id
+)
+SELECT hs.token_id,
+       COUNT(*)                                                       AS holders_count,
+       AVG(EXTRACT(EPOCH FROM (now() - hs.first_acquired)) / 86400.0) AS avg_hold_time_days,
+       now()                                                          AS computed_at
+FROM holder_state hs
+JOIN equiteez_user hu ON hu.id = hs.holder_id
+WHERE hs.balance > 0
+  AND hs.first_acquired IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM treasury t WHERE t.token_id = hs.token_id AND t.address = hu.address)
+GROUP BY hs.token_id;
+
+-- Unique index on token_id is required for REFRESH MATERIALIZED VIEW CONCURRENTLY.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_token_avg_hold_time_token_id
+    ON token_avg_hold_time(token_id);


### PR DESCRIPTION
Exposes two read surfaces the rwa-backend needs for asset `stats`: 24h trading volume per token and the launchTreasury address per token. No reindex — both live in `on_restart` (idempotent DDL over already-indexed data).

**Changes**
- `sql/on_restart/01_create-rwa-volume-view.sql` - materialized view `rwa_volume_24h_tokens`: `SUM(fulfilled_amount)` over SELL-side fills in the last 24h (one side avoids the buy+sell double-count), unique index for `REFRESH … CONCURRENTLY`.
- `sql/on_restart/02_create-token-treasury-view.sql` - view `token_launch_treasury` (`token_id → launchTreasury address`) from `launchpad_launch and launchpad_treasury`.
- `hooks/refresh_rwa_volume.py` + `dipdup.yml` - refresh hook + job (300s), mirrors `refresh_launchpad_stats`.