### PR TITLE
Handle native MAV payments in launchpad stats

### DIFF
--- a/equiteez/utils/launchpad_utils.py
+++ b/equiteez/utils/launchpad_utils.py
@@ -10,7 +10,7 @@ from equiteez.models.launchpad import (
     TokenDistributionType,
     TokenIssuanceType,
 )
-from equiteez.utils.utils import register_token
+from equiteez.utils.utils import NATIVE_MAV_ADDRESS, register_token
 
 
 _LAUNCH_STATUS_MAP = {
@@ -54,6 +54,8 @@ def payment_token_address(currency) -> Optional[str]:
         return currency.fa12
     if hasattr(currency, "fa2") and currency.fa2 is not None:
         return currency.fa2.tokenContractAddress
+    if hasattr(currency, "mav") and currency.mav is not None:
+        return NATIVE_MAV_ADDRESS
     return None
 
 

--- a/equiteez/utils/utils.py
+++ b/equiteez/utils/utils.py
@@ -3,12 +3,15 @@ from equiteez import models as models
 from dateutil import parser
 
 
+NATIVE_MAV_ADDRESS = "mv2ZZZZZZZZZZZZZZZZZZZZZZZZZZZDXMF2d"
+
+
 # Get token contract standard
 async def get_token_standard(ctx, address):
     standard = None
 
     # MVRK case
-    if address == "mv2ZZZZZZZZZZZZZZZZZZZZZZZZZZZDXMF2d":
+    if address == NATIVE_MAV_ADDRESS:
         standard = TokenType.MAV
     elif address[0:3] == "KT1" and len(address) == 36:
         contract_summary = None


### PR DESCRIPTION
### Problem
`launchpad_launch_stats.total_raised_by_token` silently dropped revenue from native MAV payments. The view aggregates by token contract address (`WHERE t.address IS NOT NULL`), but MAV payments had `payment_token = NULL` because `payment_token_address()` only resolved `fa12`/`fa2` currency variants. Result: launches paid in MAV reported `{}` (raised nothing).

### Fix
Resolve the native `mav` currency variant to the MAV sentinel address (`mv2ZZZ…DXMF2d`), so MAV is registered as a `Token` row (standard `MAV`) and joins to the token table like any FA1.2/FA2 token — no SQL/view changes needed.

- Extracted the sentinel into a `NATIVE_MAV_ADDRESS` constant in `utils.py`
- `payment_token_address()` now returns it for the `mav` variant